### PR TITLE
Enforce UDP buffer sizes

### DIFF
--- a/packages/ice/src/transport.ts
+++ b/packages/ice/src/transport.ts
@@ -12,7 +12,11 @@ import { normalizeFamilyNodeV18 } from "./utils";
 const log = debug("werift-ice:packages/ice/src/transport.ts");
 
 export class UdpTransport implements Transport {
-  private socket = createSocket(this.type);
+  private socket = createSocket({
+    type: this.type,
+    recvBufferSize: 16776960, // ~4MB
+    sendBufferSize: 65535, // 65KB
+  });
   onData: (data: Buffer, addr: Address) => void = () => {};
 
   constructor(


### PR DESCRIPTION
All this PR does is enforce sizes for the UDP socket buffers. On Windows, NodeJS seems to choose a very small buffer size by default. This results in packets being discarded, as they're read from the network faster than they can be processed.

This seems to fix the packet loss issues on windows.