### PR TITLE
Change sort order of candidate pairs to be descending priority

### DIFF
--- a/packages/ice/src/ice.ts
+++ b/packages/ice/src/ice.ts
@@ -268,7 +268,7 @@ export class Connection {
     this.unfreezeInitial();
 
     // # handle early checks
-    this.earlyChecks.forEach((earlyCheck) => this.checkIncoming(...earlyCheck));
+    this.earlyChecks.forEach((earlyCheck) => !(this.options.forceTurn && earlyCheck[2].type !== "turn") && this.checkIncoming(...earlyCheck));
     this.earlyChecks = [];
 
     // # perform checks
@@ -592,6 +592,10 @@ export class Connection {
       this.options.filterStunResponse &&
       !this.options.filterStunResponse(message, addr, protocol)
     ) {
+      return;
+    }
+
+    if (this.options.forceTurn && protocol.type !== "turn") {
       return;
     }
 
@@ -920,6 +924,7 @@ export class Connection {
   private pairRemoteCandidate = (remoteCandidate: Candidate) => {
     for (const protocol of this.protocols) {
       if (
+        !(this.options.forceTurn && protocol.type !== "turn") &&
         protocol.localCandidate?.canPairWith(remoteCandidate) &&
         !this.findPair(protocol, remoteCandidate)
       ) {

--- a/packages/ice/src/ice.ts
+++ b/packages/ice/src/ice.ts
@@ -1065,11 +1065,11 @@ export function sortCandidatePairs(
   pairs.sort(
     (a, b) =>
       candidatePairPriority(
-        a.localCandidate,
-        a.remoteCandidate,
+        b.localCandidate,
+        b.remoteCandidate,
         iceControlling
       ) -
-      candidatePairPriority(b.localCandidate, b.remoteCandidate, iceControlling)
+      candidatePairPriority(a.localCandidate, a.remoteCandidate, iceControlling)
   );
 }
 


### PR DESCRIPTION
From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#description

`compareFn(a, b)` return value | sort order
                                         > 0        | sort a after b
                                         < 0        | sort a before b
                                         === 0   | keep original order of a and b

If `candidatePairPriority` for `a` minus `candidatePairPriority` for `b` returns a *positive* value, this means `a` has a higher priority than `b`. Currently, this means a will be sorted *after* `b`. We want it to be the other way around.

