### PR TITLE
[SA-1692] Allow TURN connections to shut down

### DIFF
--- a/packages/ice/src/turn/protocol.ts
+++ b/packages/ice/src/turn/protocol.ts
@@ -224,13 +224,9 @@ class TurnClient implements Protocol {
 
       while (run) {
         // refresh before expire
-        let resolve: (value: void | PromiseLike<void>) => void = () => {};
-        const deferred = new Promise<void>((_r) => {
-          resolve = _r;
+        await new Promise<void>((resolve) => {
+          timeoutHandle = setTimeout(resolve, (5 / 6) * this.lifetime * 1000);
         });
-
-        timeoutHandle = setTimeout(resolve, (5 / 6) * this.lifetime * 1000);
-        await deferred;
 
         const request = new Message(methods.REFRESH, classes.REQUEST);
         request.setAttribute("LIFETIME", this.lifetime);


### PR DESCRIPTION
Implements a `close` function for the TURN protocol, since it didn't have one, so any opened TURN ports could never be closed.

Also allows the refresh command to be cancelled immediately, not on the next 8 minute timeout, which caused a lot of timers to pile up.