### PR TITLE
fix cand pair ordering

### DIFF
--- a/packages/ice/src/ice.ts
+++ b/packages/ice/src/ice.ts
@@ -884,6 +884,13 @@ export class Connection {
       this.remoteCandidates.push(remoteCandidate);
     }
 
+    if (this.options.forceTurn && protocol.type === "stun"){
+      return
+    }
+    if (protocol.type === "turn" && remoteCandidate.type === "host") {
+      return
+    }
+
     // find pair
     let pair = this.findPair(protocol, remoteCandidate);
     if (!pair) {
@@ -921,6 +928,8 @@ export class Connection {
     for (const protocol of this.protocols) {
       if (
         protocol.localCandidate?.canPairWith(remoteCandidate) &&
+        (!this.options.forceTurn || protocol.type === "turn") &&
+        (protocol.type === "stun" || remoteCandidate.type !== "host") &&
         !this.findPair(protocol, remoteCandidate)
       ) {
         const pair = new CandidatePair(protocol, remoteCandidate);
@@ -1065,11 +1074,11 @@ export function sortCandidatePairs(
   pairs.sort(
     (a, b) =>
       candidatePairPriority(
-        a.localCandidate,
-        a.remoteCandidate,
+        b.localCandidate,
+        b.remoteCandidate,
         iceControlling
       ) -
-      candidatePairPriority(b.localCandidate, b.remoteCandidate, iceControlling)
+      candidatePairPriority(a.localCandidate, a.remoteCandidate, iceControlling)
   );
 }
 

--- a/packages/ice/src/turn/protocol.ts
+++ b/packages/ice/src/turn/protocol.ts
@@ -282,13 +282,9 @@ class TurnClient implements Protocol {
     request
       .setAttribute("CHANNEL-NUMBER", channelNumber)
       .setAttribute("XOR-PEER-ADDRESS", addr);
-    try {
-      const [response] = await this.request(request, this.server);
-      if (response.messageMethod !== methods.CHANNEL_BIND) {
-        throw new Error();
-      }
-    } catch (err) {
-      throw err
+    const [response] = await this.request(request, this.server);
+    if (response.messageMethod !== methods.CHANNEL_BIND) {
+      throw new Error();
     }
   }
 


### PR DESCRIPTION
sortCandidatePair logic had to change - see description in https://github.com/SpalkLtd/werift-webrtc/pull/6
off the back of that turn was failing and the remedy for recv connections was to ensure that failure to bind channels was cleaned up properly, and the remedy for send connections was to ensure we weren't pairing local relay candidates with remote host candidates.
We also now only add the candidates we actually want to use to the pair list.